### PR TITLE
Add --pause option, make looped requests optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 nextbus
 =======
 
-Retrieve real-time location data from the Nextbus API and output it as JSON.
+Retrieve real-time location and prediction data from the UmoIQ (nextbus) API and output it as JSON.
 
 install
 =======
@@ -9,30 +9,80 @@ install
 If you are a Rust programmer, you can install nextbus with cargo:
 
 ```
-cargo install nextbus
+git clone https://github.com/shahin/nextbus.git &&
+  cargo install nextbus
 ```
 
 usage
 =====
 
-Stream updates for a single route at the maximum request rate:
+Get locations of all vehicles for a single route:
 ```
-$ nextbus sf-muni 12 | jq '.'
-{
-    "route": "12",
-    "direction": ,..,
-    "lat": ...,
-    "lon": ...,
-    "reportEpoch": ...,
-    "secsSinceReport": ...,
-    "predictable": ...,
-    "heading": ...,
-    "speedKmHr": ...,
-}
+nextbus locations sf-muni 22 | jq '.' | head
+```
+```
+[
+  {
+    "id": "5730",
+    "route_tag": "22",
+    "dir_tag": "22___O_F00",
+    "lat": 37.76869,
+    "lon": -122.38908,
+    "epoch": 1661190376596,
+    "predictable": true,
+    "heading": 345,
+    ...
 ```
 
-Stream updates for all routes for an agency:
+Poll for updates ever 60 seconds, for all routes for an agency:
 ```
-$ nextbus sf-muni | jq '.'
-[...]
+$ nextbus locations sf-muni --pause 60 | jq '.'
 ```
+```
+[
+  {
+    "id": "5816",
+    "route_tag": "1",
+    "dir_tag": "",
+    "lat": 37.779816,
+    "lon": -122.4931,
+    "epoch": 1661190398737,
+    "predictable": true,
+    "heading": 269,
+    ...
+```
+
+Get predicted arrival times for given stop IDs:
+```
+nextbus predictions sf-muni 22 -- 4618 | jq '.'
+```
+```
+nextbus predictions sf-muni 22 -- 4618 | jq '.'
+{
+  "predictions": [
+    {
+      "direction": [
+        {
+          "title": "Outbound to UCSF Mission Bay",
+          "prediction": [
+            {
+              "epochTime": 1661191317835,
+              "seconds": 772,
+              "minutes": 12,
+              "isDeparture": false,
+              "dirTag": "22___O_F00",
+              "affectedByLayover": false,
+              "delayed": false,
+              "slowness": 0,
+              "vehicle": "5717",
+              "vehiclesInConsist": 0,
+              "block": "2206",
+              "tripTag": "11031088"
+            },
+            ...
+```
+
+references
+==========
+
+- UmoIQ API Specification: https://retro.umoiq.com/xmlFeedDocs/NextBusXMLFeed.pdf

--- a/src/location.rs
+++ b/src/location.rs
@@ -93,7 +93,7 @@ pub fn get_locations(agency: String, route: String, pause_seconds: Option<u64>) 
         match downloaded {
             Some(locations) => {
                 let locations_json;
-                ((locations_json, epoch) = parse_locations(locations));
+                (locations_json, epoch) = parse_locations(locations);
                 println!("{}", locations_json);
             }
             None => (),

--- a/src/location.rs
+++ b/src/location.rs
@@ -91,6 +91,8 @@ pub fn get_locations(agency: String, route: String, pause_seconds: Option<u64>) 
         });
 
         match downloaded {
+            // a successful response may contain no locations if there are no vehicles, or
+            // if there are no updates to vehicle locations since the last given epoch
             Some(locations) => {
                 let locations_json;
                 (locations_json, epoch) = parse_locations(locations);

--- a/src/main.rs
+++ b/src/main.rs
@@ -54,6 +54,7 @@ fn main() -> Result<(), impl Error> {
             .about("Get real-time locations for vehicles")
             .args_from_usage("<agency> 'Agency of the route to retrieve locations for (ex: sf-muni)'")
             .args_from_usage("[route] 'Optional name of the route to retrieve locations for (default: all routes)'")
+            .args_from_usage("-p, --pause=[SECONDS] 'Repeat the request after pausing for the given SECONDS'")
         )
         .subcommand(SubCommand::with_name("predictions")
             .about("Get predictions for vehicle arrival times")
@@ -124,7 +125,14 @@ fn main() -> Result<(), impl Error> {
         ("locations", Some(subc)) => {
             let route = String::from(subc.value_of("route").unwrap_or(""));
             let agency = String::from(subc.value_of("agency").unwrap());
-            location::get_locations(agency, route)
+            let pause_seconds = match subc.value_of("pause") {
+                None => None,
+                Some(s) => Some(
+                    s.parse::<u64>()
+                        .expect(&format!("Must provide a positive integer, got '{}'", s)),
+                ),
+            };
+            location::get_locations(agency, route, pause_seconds)
         }
         ("predictions", Some(subc)) => {
             let route = String::from(subc.value_of("route").unwrap_or(""));

--- a/src/main.rs
+++ b/src/main.rs
@@ -66,6 +66,12 @@ fn main() -> Result<(), impl Error> {
                     .help("Route to get predictions for (ex: N)")
                     .index(2)
                     .required(true),
+                Arg::with_name("pause_seconds")
+                    .short("p")
+                    .long("--pause")
+                    .value_name("SECONDS")
+                    .help("Repeat the request after pausing for the given SECONDS")
+                    .required(false),
                 Arg::with_name("stops")
                     .help("Stop tags to get predictions for (ex: 6997)")
                     .required(false)
@@ -123,6 +129,13 @@ fn main() -> Result<(), impl Error> {
         ("predictions", Some(subc)) => {
             let route = String::from(subc.value_of("route").unwrap_or(""));
             let agency = String::from(subc.value_of("agency").unwrap());
+            let pause_seconds = match subc.value_of("pause_seconds") {
+                None => None,
+                Some(s) => Some(
+                    s.parse::<u64>()
+                        .expect(&format!("Must provide a positive integer, got {}", s)),
+                ),
+            };
             let stops: Vec<String> = match subc.values_of("stops") {
                 Some(stops) => stops
                     .collect::<Vec<_>>()
@@ -131,7 +144,7 @@ fn main() -> Result<(), impl Error> {
                     .collect(),
                 None => Vec::new(),
             };
-            prediction::get_predictions(agency, route, stops)
+            prediction::get_predictions(agency, route, stops, pause_seconds)
         }
         ("schedule", Some(subc)) => {
             let route = String::from(subc.value_of("route").unwrap_or(""));


### PR DESCRIPTION
Before, this command would make requests indefinitely and pause 20 seconds between a response and the next request:
```
cargo run -- locations sf-muni 22
```

Now, this command returns after one response. To reproduce previous behavior, use the `--pause` option:
```
cargo run -- locations sf-muni 22 --pause 20
```

The same change was made to the `predictions` subcommand.